### PR TITLE
그밖에...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@
 #### 3. [Stream](https://github.com/Junhan0037/java-java8/pull/3)
 #### 4. [Optional](https://github.com/Junhan0037/java-java8/pull/4)
 #### 5. [Date와 Time API](https://github.com/Junhan0037/java-java8/pull/5)
+#### 6. [CompletableFuture](https://github.com/Junhan0037/java-java8/pull/6)
+#### 7. [그밖에](https://github.com/Junhan0037/java-java8/pull/7)
 
 해당 repo는 [더 자바, Java 8 - 백기선](https://www.inflearn.com/course/the-java-java8) 해당 강의를 듣고 정리한 REPO 입니다.

--- a/src/main/java/com/java8to11/chapter07/App.java
+++ b/src/main/java/com/java8to11/chapter07/App.java
@@ -1,0 +1,18 @@
+package com.java8to11.chapter07;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class App {
+
+    public static void main(String[] args) {
+        List<@Egg String> naems = Arrays.asList("junhan");
+    }
+
+    static class FeelsLikeChicken<@Egg T> {
+        public static <@Egg C> void print(@Egg C c) {
+            System.out.println(c);
+        }
+    }
+
+}

--- a/src/main/java/com/java8to11/chapter07/App2.java
+++ b/src/main/java/com/java8to11/chapter07/App2.java
@@ -1,0 +1,22 @@
+package com.java8to11.chapter07;
+
+import java.util.Arrays;
+
+@Chicken("후라이드")
+@Chicken("양념")
+@Chicken("간장")
+public class App2 {
+    public static void main(String[] args) {
+
+        Chicken[] chickens = App2.class.getAnnotationsByType(Chicken.class);
+        Arrays.stream(chickens).forEach(c -> {
+            System.out.println(c.value());
+        });
+
+        ChickenContainer chickenContainer = App2.class.getAnnotation(ChickenContainer.class);
+        Arrays.stream(chickenContainer.value()).forEach(c -> {
+            System.out.println(c.value());
+        });
+
+    }
+}

--- a/src/main/java/com/java8to11/chapter07/Chicken.java
+++ b/src/main/java/com/java8to11/chapter07/Chicken.java
@@ -1,0 +1,10 @@
+package com.java8to11.chapter07;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@Repeatable(ChickenContainer.class)
+public @interface Chicken {
+    String value();
+}

--- a/src/main/java/com/java8to11/chapter07/ChickenContainer.java
+++ b/src/main/java/com/java8to11/chapter07/ChickenContainer.java
@@ -1,0 +1,12 @@
+package com.java8to11.chapter07;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface ChickenContainer {
+    Chicken[] value();
+}

--- a/src/main/java/com/java8to11/chapter07/Egg.java
+++ b/src/main/java/com/java8to11/chapter07/Egg.java
@@ -1,0 +1,12 @@
+package com.java8to11.chapter07;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+//@Target(ElementType.TYPE_PARAMETER)
+@Target(ElementType.TYPE_USE)
+public @interface Egg {
+}

--- a/src/main/java/com/java8to11/chapter08/App.java
+++ b/src/main/java/com/java8to11/chapter08/App.java
@@ -1,0 +1,25 @@
+package com.java8to11.chapter08;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+public class App {
+    public static void main(String[] args) {
+
+        int size = 1500;
+        int[] numbers = new int[size];
+        Random random = new Random();
+
+        IntStream.range(0, size).forEach(i -> numbers[i] = random.nextInt());
+        long start = System.nanoTime();
+        Arrays.sort(numbers);
+        System.out.println("serial sorting took : " + (System.nanoTime() - start));
+
+        IntStream.range(0, size).forEach(i -> numbers[i] = random.nextInt());
+        start = System.nanoTime();
+        Arrays.parallelSort(numbers); // 배열 병렬 정렬
+        System.out.println("parallel sorting took : " + (System.nanoTime() - start));
+
+    }
+}


### PR DESCRIPTION
## 애노테이션의 변화

### 애노테이션 관련 두가지 큰 변화
- 자바 8부터 애노테이션을 타입 선언부에도 사용할 수 있게 됨.
- 자바 8부터 애노테이션을 중복해서 사용할 수 있게 됨.

### 타입 선언 부
- 제네릭 타입
- 변수 타입
- 매개변수 타입
- 예외 타입
- ...

### 타입에 사용할 수 있으려면
- TYPE_PARAMETER: 타입 변수에만 사용할 수 있다.
- TYPE_USE: 타입 변수를 포함해서 모든 타입 선언부에 사용할 수 있다.

### 중복 사용할 수 있는 애노테이션을 만들기
- 중복 사용할 애노테이션 만들기
- 중복 애노테이션 컨테이너 만들기
    - 컨테이너 애노테이션은 중복 애노테이션과 @Retention 및 @Target이 같거나 더 넓어야 한다.

## 배열 Parallel 정렬

### Arrays.parallelSort()
- Fork/Join 프레임워크를 사용해서 배열을 병렬로 정렬하는 기능을 제공한다.

### 병렬 정렬 알고리듬
- 배열을 둘로 계속 쪼갠다.
- 합치면서 정렬한다.

## Metaspace

JVM의 여러 메모리 영역 중에 PermGen 메모리 영역이 없어지고 Metaspace 영역이 생겼다.

### PermGen
- permanent generation, 클래스 메타데이터를 담는 곳.
- **Heap 영역에 속함.**
- **기본값으로 제한된 크기를 가지고 있음.**
- -XX:PermSize=N, PermGen 초기 사이즈 설정
- -XX:MaxPermSize=N, PermGen 최대 사이즈 설정

### Metaspace
- 클래스 메타데이터를 담는 곳.
- **Heap 영역이 아니라, Native 메모리 영역이다.**
- **기본값으로 제한된 크기를 가지고 있지 않다. (필요한 만큼 계속 늘어난다.)**
- 자바 8부터는 PermGen 관련 java 옵션은 무시한다.
- -XX:MetaspaceSize=N, Metaspace 초기 사이즈 설정.
- -XX:MaxMetaspaceSize=N, Metaspace 최대 사이즈 설정.

### 참고
- http://mail.openjdk.java.net/pipermail/hotspot-dev/2012-September/006679.html
- https://m.post.naver.com/viewer/postView.nhn?volumeNo=23726161&memberNo=36733075
- https://m.post.naver.com/viewer/postView.nhn?volumeNo=24042502&memberNo=36733075
- https://dzone.com/articles/java-8-permgen-metaspace
